### PR TITLE
add no_std support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
+#![no_std]
 
 /// Define a const map and a const lookup function as associated items of a struct.
 ///


### PR DESCRIPTION
This seems to allow importing and using the macro in `no_std` code, e.g. in embedded (microcontrollers firmware).